### PR TITLE
Utilize SensitiveParameter attribute

### DIFF
--- a/src/Crypto.php
+++ b/src/Crypto.php
@@ -22,7 +22,10 @@ class Crypto
      *
      * @param string $key The "key" value, either a string or a file path
      */
-    public function __construct($key)
+    public function __construct(
+        #[\SensitiveParameter]
+        $key
+    )
     {
         $this->setKey($this->createKey($key));
     }
@@ -33,7 +36,10 @@ class Crypto
      * @param string $key The "key" value, either a string or a file path
      * @return KeySource instance
      */
-    public function createKey(string $key)
+    public function createKey(
+        #[\SensitiveParameter]
+        string $key
+    )
     {
         if (is_file($key)) {
             $key = new KeySource\KeyFile($key);
@@ -72,7 +78,10 @@ class Crypto
      * @param string $value Value to encrypt
      * @return string Ciphertext (encrypted) value
      */
-    public function encrypt($value)
+    public function encrypt(
+        #[\SensitiveParameter]
+        $value
+    )
     {
         // Get the key contents, no sense in keeping it in memory for too long
         $keyAscii = trim($this->key->getContent());
@@ -87,7 +96,10 @@ class Crypto
      * @param string $value Ciphertext (encrypted) string
      * @return mixed The value if it could be decrypted, otherwse null
      */
-    public function decrypt($value)
+    public function decrypt(
+        #[\SensitiveParameter]
+        $value
+    )
     {
         try {
             $keyAscii = trim($this->key->getContent());

--- a/src/Crypto.php
+++ b/src/Crypto.php
@@ -25,8 +25,7 @@ class Crypto
     public function __construct(
         #[\SensitiveParameter]
         $key
-    )
-    {
+    ) {
         $this->setKey($this->createKey($key));
     }
 
@@ -39,8 +38,7 @@ class Crypto
     public function createKey(
         #[\SensitiveParameter]
         string $key
-    )
-    {
+    ) {
         if (is_file($key)) {
             $key = new KeySource\KeyFile($key);
         } elseif (is_string($key)) {
@@ -81,8 +79,7 @@ class Crypto
     public function encrypt(
         #[\SensitiveParameter]
         $value
-    )
-    {
+    ) {
         // Get the key contents, no sense in keeping it in memory for too long
         $keyAscii = trim($this->key->getContent());
         return DefuseCrypto::encrypt($value, DefuseKey::loadFromAsciiSafeString($keyAscii));
@@ -99,8 +96,7 @@ class Crypto
     public function decrypt(
         #[\SensitiveParameter]
         $value
-    )
-    {
+    ) {
         try {
             $keyAscii = trim($this->key->getContent());
             $value = DefuseCrypto::decrypt($value, DefuseKey::loadFromAsciiSafeString($keyAscii));

--- a/src/KeySource/KeyString.php
+++ b/src/KeySource/KeyString.php
@@ -11,7 +11,10 @@ class KeyString extends KeySource
      *
      * @param string $source File path for the key
      */
-    public function __construct(string $source)
+    public function __construct(
+        #[\SensitiveParameter]
+        string $source
+    )
     {
         $this->setContent($source);
     }

--- a/src/KeySource/KeyString.php
+++ b/src/KeySource/KeyString.php
@@ -14,8 +14,7 @@ class KeyString extends KeySource
     public function __construct(
         #[\SensitiveParameter]
         string $source
-    )
-    {
+    ) {
         $this->setContent($source);
     }
 }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -35,8 +35,7 @@ class Parser
         #[\SensitiveParameter]
         $key,
         $configPath = null
-    )
-    {
+    ) {
         $this->setCrypto(new Crypto($key));
 
         if (null == $configPath) {
@@ -54,8 +53,7 @@ class Parser
     public function decryptValues(
         #[\SensitiveParameter]
         array $values
-    ): array
-    {
+    ): array {
         foreach ($values as $index => $value) {
             if (is_array($value)) {
                 foreach ($value as $i => $v) {
@@ -115,8 +113,7 @@ class Parser
         #[\SensitiveParameter]
         $keyValue,
         $overwrite = false
-    ): bool
-    {
+    ): bool {
         return $this->writeEnv($keyName, $keyValue, $overwrite);
     }
 
@@ -133,8 +130,7 @@ class Parser
         #[\SensitiveParameter]
         $keyValue,
         bool $overwrite = false
-    )
-    {
+    ) {
         $contents = $this->loadFile($this->configPath);
 
         // read from the .env file, update any that need it or add a new one

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -31,7 +31,11 @@ class Parser
      * @param string $key Key value or file path to key
      * @param string $configPath Path to the .env configuration file
      */
-    public function __construct($key, $configPath = null)
+    public function __construct(
+        #[\SensitiveParameter]
+        $key,
+        $configPath = null
+    )
     {
         $this->setCrypto(new Crypto($key));
 
@@ -47,7 +51,10 @@ class Parser
      *
      * @return array Decrypted values
      */
-    public function decryptValues(array $values): array
+    public function decryptValues(
+        #[\SensitiveParameter]
+        array $values
+    ): array
     {
         foreach ($values as $index => $value) {
             if (is_array($value)) {
@@ -103,7 +110,12 @@ class Parser
      * @param bool $overwrite Flag to either overwrite the value that exists or leave it
      * @return bool Success/fail of the write
      */
-    public function save($keyName, $keyValue, $overwrite = false): bool
+    public function save(
+        $keyName,
+        #[\SensitiveParameter]
+        $keyValue,
+        $overwrite = false
+    ): bool
     {
         return $this->writeEnv($keyName, $keyValue, $overwrite);
     }
@@ -116,7 +128,12 @@ class Parser
      * @throws Exception If the key name already exists and the overwrite flag isn't true
      * @return bool Success/fail of file write
      */
-    public function writeEnv(string $keyName, $keyValue, bool $overwrite = false)
+    public function writeEnv(
+        string $keyName,
+        #[\SensitiveParameter]
+        $keyValue,
+        bool $overwrite = false
+    )
     {
         $contents = $this->loadFile($this->configPath);
 


### PR DESCRIPTION
This PR adds the php native `SensitiveParameter` to parameters which are secruity relevant.
When the code is running on PHP8.2+ this will lead to masking of the contents, so we don't leak secrets into logfiles or with debug out.

I am putting the `#[SensitiveParameter]` onto a separate line, to make sure the code stays PHP 7.x compatible.
In case we would put the attribute onto the same line as the parameters, we would loose PHP7.x compatibility.
As is, PHP7.x will treat this line as a full-line comment and just ignore it.

see https://php.watch/versions/8.2/backtrace-parameter-redaction#SensitiveParameter