### PR TITLE
Implement LazySecret

### DIFF
--- a/src/LazySecret.php
+++ b/src/LazySecret.php
@@ -15,6 +15,8 @@ final class LazySecret
      */
     private $decrypter;
 
+    private ?string $decrypted = null;
+
     /**
      * @param callable(): ?string $decrypter
      */
@@ -26,12 +28,18 @@ final class LazySecret
         $this->decrypter = $decrypter;
     }
 
+    /**
+     * @throws RuntimeException
+     */
     public function __toString(): string
     {
-        $decrypted = ($this->decrypter)();
-        if (null === $decrypted) {
-            throw new RuntimeException(sprintf('Unable to decrypt secret %s', $this->identifier));
+        if ($this->decrypted === null) {
+            $decrypted = ($this->decrypter)();
+            if (null === $decrypted) {
+                throw new RuntimeException(sprintf('Unable to decrypt secret %s', $this->identifier));
+            }
+            $this->decrypted = $decrypted;
         }
-        return $decrypted;
+        return $this->decrypted;
     }
 }

--- a/src/LazySecret.php
+++ b/src/LazySecret.php
@@ -33,7 +33,7 @@ final class LazySecret
      */
     public function __toString(): string
     {
-        if ($this->decrypted === null) {
+        if (null === $this->decrypted) {
             $decrypted = ($this->decrypter)();
             if (null === $decrypted) {
                 throw new RuntimeException(sprintf('Unable to decrypt secret %s', $this->identifier));

--- a/src/LazySecret.php
+++ b/src/LazySecret.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace staabm\SecureDotenv;
+
+use RuntimeException;
+
+use function sprintf;
+
+final class LazySecret
+{
+    private string $identifier;
+
+    /**
+     * @var callable(): ?string
+     */
+    private $decrypter;
+
+    /**
+     * @param callable(): ?string $decrypter
+     */
+    public function __construct(
+        string $identifier,
+        callable $decrypter
+    ) {
+        $this->identifier = $identifier;
+        $this->decrypter = $decrypter;
+    }
+
+    public function __toString(): string
+    {
+        $decrypted = ($this->decrypter)();
+        if (null === $decrypted) {
+            throw new RuntimeException(sprintf('Unable to decrypt secret %s', $this->identifier));
+        }
+        return $decrypted;
+    }
+}

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -6,6 +6,7 @@ use Exception;
 use InvalidArgumentException;
 
 use function is_array;
+use function trim;
 
 class Parser
 {
@@ -57,12 +58,14 @@ class Parser
         foreach ($values as $index => $value) {
             if (is_array($value)) {
                 foreach ($value as $i => $v) {
-                    $de = $this->crypto->decrypt(trim($v));
-                    $values[$index][$i] = (null == $de) ? $v : $de;
+                    $values[$index][$i] = new LazySecret($index.'_'.$i, function () use ($v) {
+                        return $this->crypto->decrypt(trim($v));
+                    });
                 }
             } else {
-                $de = $this->crypto->decrypt(trim($value));
-                $values[$index] = (null == $de) ? $value : $de;
+                $values[$index] = new LazySecret($index, function () use ($value) {
+                    return $this->crypto->decrypt(trim($value));
+                });
             }
         }
         return $values;

--- a/tests/LazySecretTest.php
+++ b/tests/LazySecretTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace staabm\SecureDotenv;
+
+use PHPUnit\Framework\TestCase;
+
+class LazySecretTest extends TestCase {
+    public function testDecryptOnce() {
+        $i = 0;
+        $lazy = new LazySecret('id', function() use (&$i) {
+            $i++;
+            return 'abc';
+        });
+        $lazy->__toString();
+        $lazy->__toString();
+        $lazy->__toString();
+        $this->assertSame(1, $i);
+    }
+}

--- a/tests/LazySecretTest.php
+++ b/tests/LazySecretTest.php
@@ -4,16 +4,21 @@ namespace staabm\SecureDotenv;
 
 use PHPUnit\Framework\TestCase;
 
-class LazySecretTest extends TestCase {
-    public function testDecryptOnce() {
+/**
+ * @internal
+ */
+class LazySecretTest extends TestCase
+{
+    public function testDecryptOnce()
+    {
         $i = 0;
-        $lazy = new LazySecret('id', function() use (&$i) {
-            $i++;
+        $lazy = new LazySecret('id', static function () use (&$i) {
+            ++$i;
             return 'abc';
         });
         $lazy->__toString();
         $lazy->__toString();
         $lazy->__toString();
-        $this->assertSame(1, $i);
+        static::assertSame(1, $i);
     }
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -4,7 +4,6 @@ namespace staabm\SecureDotenv;
 
 use Exception;
 use InvalidArgumentException;
-use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -55,9 +54,9 @@ class ParserTest extends TestCase
         $parser = new Parser($this->keyPath, $this->envPath);
         $loadedValues = $parser->loadFile($this->envPath);
 
-        foreach($loadedValues as $loadedValue) {
-            $this->assertInstanceOf(LazySecret::class, $loadedValue);
-            $this->assertEquals('test1234', (string) $loadedValue);
+        foreach ($loadedValues as $loadedValue) {
+            static::assertInstanceOf(LazySecret::class, $loadedValue);
+            static::assertEquals('test1234', (string) $loadedValue);
         }
     }
 

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -4,6 +4,7 @@ namespace staabm\SecureDotenv;
 
 use Exception;
 use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -45,6 +46,19 @@ class ParserTest extends TestCase
         $parser->setCrypto($c);
 
         static::assertEquals(190, $parser->save('env1', 'test1234', true));
+    }
+
+    public function testLazyParsing()
+    {
+        $this->testSave();
+
+        $parser = new Parser($this->keyPath, $this->envPath);
+        $loadedValues = $parser->loadFile($this->envPath);
+
+        foreach($loadedValues as $loadedValue) {
+            $this->assertInstanceOf(LazySecret::class, $loadedValue);
+            $this->assertEquals('test1234', (string) $loadedValue);
+        }
     }
 
     public function testWriteEnvWithDuplicatedEnv()


### PR DESCRIPTION
lazy decrypt secrets to make sure we don't waste time on decrypting all secrets of a .env file, in case we only need a few of them.

decrypting secrets shows up in blackfire profiles can take 60-70ms for ~30 secrets.

<img width="267" height="604" alt="grafik" src="https://github.com/user-attachments/assets/2b57cb12-4d78-4e00-b4c9-0a1cb35ce344" />
